### PR TITLE
prevent adding of invalid orders in the past

### DIFF
--- a/domain/src/position/position.derivers.ts
+++ b/domain/src/position/position.derivers.ts
@@ -78,6 +78,14 @@ export function getPositionHistory(orders: Order[]): PositionHistory {
   return history;
 }
 
+export const getPositionsAtTimeStamp = (
+  orders: Order[],
+  timeStampOfInterest: number
+): Positions =>
+  getPositionHistory(orders).findLast(
+    ({ date }) => date.getTime() <= timeStampOfInterest
+  )?.positions || EMPTY_POSITIONS;
+
 function updatePositionsWithActivity(
   positions: Positions | undefined,
   activity: PortfolioActivity

--- a/frontend/src/components/Portfolios/OrderInputForm/OrderInputForm.logic.ts
+++ b/frontend/src/components/Portfolios/OrderInputForm/OrderInputForm.logic.ts
@@ -1,0 +1,18 @@
+import { Order } from "../../../../../domain/src/order/order.entities";
+import {
+  isOrderValidForPortfolio,
+  portfolioContainsOrder,
+} from "../../../../../domain/src/portfolio/portfolio.derivers";
+import { useGetPortfolio } from "../../../hooks/portfolios/portfolioHooks";
+
+export const useOrderValidation = (portfolioName: string) => {
+  const { isSuccess: isReady, data } = useGetPortfolio(portfolioName);
+
+  const isValid = (order: Order | undefined) =>
+    isReady && order ? isOrderValidForPortfolio(data, order) : false;
+
+  const isDuplicate = (order: Order | undefined) =>
+    isReady && order ? portfolioContainsOrder(data, order) : false;
+
+  return { isReady, isValid, isDuplicate };
+};

--- a/frontend/src/components/Portfolios/OrderInputForm/OrderInputFrom.test.tsx
+++ b/frontend/src/components/Portfolios/OrderInputForm/OrderInputFrom.test.tsx
@@ -2,6 +2,7 @@ import { act, screen } from "@testing-library/react";
 import {
   TEST_ASSET_LIB,
   TEST_ASSET_TESLA,
+  TEST_ORDER_TESLA,
   TEST_PORTFOLIO,
   TEST_PORTFOLIO_LIB,
 } from "../../../../../domain/src/testConstants";
@@ -91,5 +92,40 @@ describe("The OrderInputForm", () => {
     expect(screen.getByTitle("Summary Text")).toHaveTextContent(
       "4 x 400 + 1 = 1601.00"
     );
+  });
+
+  it("shows a warning if the user tries to add a duplicate order", async () => {
+    const { selectAsset, fillNumberInput, user } = customRender({
+      component: <OrderInputForm {...PROPS} />,
+    });
+
+    await selectAsset(TEST_ASSET.displayName);
+    await fillNumberInput({
+      label: "Pieces",
+      value: `${TEST_ORDER_TESLA.pieces}`,
+    });
+    await fillNumberInput({
+      label: "Fees",
+      value: `${TEST_ORDER_TESLA.orderFee}`,
+    });
+    await fillNumberInput({
+      label: "Share Price",
+      value: `${TEST_ORDER_TESLA.sharePrice}`,
+    });
+    const dateInput = await screen.findByLabelText("Order Date");
+
+    await user.clear(dateInput);
+
+    await user.type(
+      await screen.findByLabelText("Order Date"),
+      `${TEST_ORDER_TESLA.timestamp}`
+    );
+    await act(async () => {
+      await user.click(await screen.findByRole("button", { name: "Submit" }));
+    });
+
+    expect(
+      await screen.findByText(/duplicate order detected!/i)
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Now, the order input form checks if the user has enough pieces to sell at time of the order data (instead of now)