### PR TITLE
Make NumberInput accept commas as delimiter

### DIFF
--- a/frontend/src/components/Portfolios/OrderInputForm/OrderInputFrom.tsx
+++ b/frontend/src/components/Portfolios/OrderInputForm/OrderInputFrom.tsx
@@ -87,7 +87,6 @@ export function OrderInputForm({
         className={bemElement("sharePrice")}
         onChange={setSharePrice}
         label={"Share Price"}
-        digits={2}
         defaultValue={DEFAULTS.sharePrice}
         isMandatory={true}
         autoComplete={"off"}
@@ -96,7 +95,6 @@ export function OrderInputForm({
         className={bemElement("fees")}
         onChange={setFees}
         label={"Fees"}
-        digits={2}
         defaultValue={DEFAULTS.fees}
         isMandatory={false}
         autoComplete={"off"}
@@ -105,7 +103,6 @@ export function OrderInputForm({
         className={bemElement("taxes")}
         onChange={setTaxes}
         label={"Taxes"}
-        digits={2}
         defaultValue={DEFAULTS.taxes}
         isMandatory={false}
         autoComplete={"off"}

--- a/frontend/src/components/Portfolios/PortfolioFormSideBar/DividendForm/DividendForm.tsx
+++ b/frontend/src/components/Portfolios/PortfolioFormSideBar/DividendForm/DividendForm.tsx
@@ -77,12 +77,10 @@ function DividendForm({ portfolioName }: DividendFormProps): ReactElement {
           setFormState({ ...formState, dividendPerShare: dividend })
         }
         isMandatory
-        digits={2}
       />
       <NumberInput
         label={"Total Taxes"}
         onChange={(taxes) => setFormState({ ...formState, taxes })}
-        digits={2}
       />
       <DateInput
         label={"Payout Date"}

--- a/frontend/src/components/general/NumberInput/NumberInput.test.tsx
+++ b/frontend/src/components/general/NumberInput/NumberInput.test.tsx
@@ -28,104 +28,79 @@ describe("the NumberInput component", () => {
     render(<NumberInput {...PROPS} />);
     const field = await screen.findByLabelText(LABEL);
     await fillInput("12ab3");
-    expect(field).toHaveValue("123");
+    expect(field).toHaveValue(123);
   });
 
   it("can delete a character with backspace", async () => {
     render(<NumberInput {...PROPS} />);
     const field = screen.getByLabelText(LABEL);
     await fillInput("12");
-    expect(field).toHaveValue("12");
+    expect(field).toHaveValue(12);
     await fillInput("{Backspace}");
-    expect(field).toHaveValue("1");
+    expect(field).toHaveValue(1);
   });
 
   it("last character can be deleted", async () => {
     render(<NumberInput {...PROPS} />);
     const field = screen.getByLabelText(LABEL);
     await fillInput("12");
-    expect(field).toHaveValue("12");
+    expect(field).toHaveValue(12);
     await fillInput("{Backspace} {Backspace}");
-    expect(field).toHaveValue("");
+    expect(field).toHaveValue(null);
   });
 
   it("accepts decimal numbers with '.' as separator", async () => {
     render(<NumberInput {...PROPS} />);
     const field = screen.getByLabelText(LABEL);
     await fillInput("1.77");
-    expect(field).toHaveValue("1.77");
+    expect(field).toHaveValue(1.77);
   });
 
   it("correctly parses a number ending in '.'", async () => {
     render(<NumberInput {...PROPS} />);
     const field = screen.getByLabelText(LABEL);
     await fillInput("2.");
-    expect(field).toHaveValue("2.");
-  });
-
-  it("can limit the number of digits", async () => {
-    render(<NumberInput {...PROPS} digits={3} />);
-    const field = screen.getByLabelText(LABEL);
-    await fillInput("1.7734545");
-    expect(field).toHaveValue("1.773");
+    expect(field).toHaveValue(2);
   });
 
   it("accepts negative numbers", async () => {
     render(<NumberInput {...PROPS} />);
     const field = screen.getByLabelText(LABEL);
     await fillInput("-1.7");
-    expect(field).toHaveValue("-1.7");
+    expect(field).toHaveValue(-1.7);
   });
 
   it("accepts numbers starting with a decimal point", async () => {
     render(<NumberInput {...PROPS} />);
     const field = screen.getByLabelText(LABEL);
     await fillInput(".7");
-    expect(field).toHaveValue("0.7");
+    expect(field).toHaveValue(0.7);
   });
 
   it("accepts negative numbers starting with a decimal point", async () => {
     render(<NumberInput {...PROPS} />);
     const field = screen.getByLabelText(LABEL);
     await fillInput("-.7");
-    expect(field).toHaveValue("-0.7");
+    expect(field).toHaveValue(-0.7);
   });
 
   it("can be prefilled with a default value", () => {
     render(<NumberInput {...PROPS} defaultValue={1.4} />);
     const field = screen.getByLabelText(LABEL);
-    expect(field).toHaveValue("1.4");
-  });
-
-  it("crops the default value to the specified number of digits", () => {
-    render(<NumberInput {...PROPS} defaultValue={1.442} digits={2} />);
-    const field = screen.getByLabelText(LABEL);
-    expect(field).toHaveValue("1.44");
+    expect(field).toHaveValue(1.4);
   });
 
   it("can modify a given defaultValue", async () => {
-    render(<NumberInput {...PROPS} defaultValue={1.4} digits={3} />);
-    const field = screen.getByLabelText(LABEL);
-    await fillInput("{Backspace}{Backspace}");
-    expect(field).toHaveValue("1");
+    render(<NumberInput {...PROPS} defaultValue={1.4} />);
+    await fillInput("{Backspace}");
     expect(onChangeMock).toHaveBeenLastCalledWith(1);
   });
 
-  describe("sets the value to undefined if the user input is", () => {
-    it("empty", async () => {
-      render(<NumberInput {...PROPS} />);
-      const field = screen.getByLabelText(LABEL);
-      await fillInput("1{Backspace}");
-      expect(field).toHaveValue("");
-      expect(onChangeMock.mock.calls).toEqual([[1], [undefined]]);
-    });
-
-    it("not a valid number, but a potential number", async () => {
-      render(<NumberInput {...PROPS} />);
-      const field = screen.getByLabelText(LABEL);
-      await fillInput("-");
-      expect(field).toHaveValue("-");
-      expect(onChangeMock.mock.calls).toEqual([[undefined]]);
-    });
+  it("empty", async () => {
+    render(<NumberInput {...PROPS} />);
+    const field = screen.getByLabelText(LABEL);
+    await fillInput("1{Backspace}");
+    expect(field).toHaveValue(null);
+    expect(onChangeMock.mock.calls).toEqual([[1], [undefined]]);
   });
 });

--- a/frontend/src/components/general/NumberInput/NumberInput.tsx
+++ b/frontend/src/components/general/NumberInput/NumberInput.tsx
@@ -9,7 +9,6 @@ export type NumberInputValue = number | undefined;
 
 export interface NumberInputProps extends InputProps {
   onChange: (value: NumberInputValue) => void;
-  digits?: number;
   defaultValue?: number;
 }
 
@@ -20,32 +19,16 @@ export const NumberInput = ({
   className,
   errorMessage,
   onChange,
-  digits,
   defaultValue,
   ...rest
 }: NumberInputProps): ReactElement => {
-  const [display, setDisplay] = useState(
-    getStringOfDefaultValue(defaultValue, digits)
-  );
+  const [display, setDisplay] = useState(defaultValue?.toString() || "");
 
-  const potentialNumberRegex = new RegExp(
-    `^(-|\\+)?\\d{0,}\\.?\\d{0,${digits || ""}}$`
-  );
-
-  const numberRegex = new RegExp(
-    `^(-|\\+)?\\d{1,}(\\.\\d{0,${digits || ""}})?$`
-  );
-
-  const handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void = (
-    event
-  ) => {
-    const amount = insertPotentiallyMissingZero(event.target.value);
-    if (amount.match(potentialNumberRegex)) {
-      setDisplay(amount);
-      amount.match(numberRegex)
-        ? onChange(parseFloat(amount))
-        : onChange(undefined);
-    }
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newDisplay = event.target.value;
+    setDisplay(newDisplay);
+    const parsedValue = parseFloat(newDisplay);
+    onChange(Number.isNaN(parsedValue) ? undefined : parsedValue);
   };
 
   return (
@@ -58,7 +41,8 @@ export const NumberInput = ({
       <input
         id={`${label?.replaceAll(" ", "-") || ""}-input`}
         className={bemElement("field", isMandatory ? "mandatory" : "")}
-        type="text"
+        type="number"
+        step={0.01}
         value={display}
         onChange={handleChange}
         autoComplete="off"
@@ -67,25 +51,3 @@ export const NumberInput = ({
     </InputWrapper>
   );
 };
-
-const getStringOfDefaultValue: (
-  value: number | undefined,
-  digits: number | undefined
-) => string = (value, digits) => {
-  if (value === undefined) {
-    return "";
-  }
-  if (!digits) {
-    return value.toString();
-  }
-
-  const currentDigits = value.toString().split(".")[1]?.length || 0;
-  return value.toFixed(Math.min(digits, currentDigits)).toString();
-};
-
-function insertPotentiallyMissingZero(number: string): string {
-  if (number.match(/^(-|\+)?\./)) {
-    return number.replace(".", "0.");
-  }
-  return number;
-}


### PR DESCRIPTION
* The NumberInput uses the browser functionalities to decide which charaters to accept. Most custom logic is gone.
* The two digit restriction for price inputs is removed.