### PR TITLE
extend history chart data to today

### DIFF
--- a/frontend/src/components/charts/portfolioHistory/PortfolioHistoryChart.logic.test.tsx
+++ b/frontend/src/components/charts/portfolioHistory/PortfolioHistoryChart.logic.test.tsx
@@ -123,6 +123,8 @@ describe("useGetPortfolioHistoryChartData", () => {
         timestamp: TIMESTAMPS[3],
       },
       {
+        buyValue: 232.7,
+        cashFlow: 232.7,
         marketValue: 2 * 110 + 3 * 10.3,
         timestamp: new Date(TODAY).getTime(),
       },

--- a/frontend/src/components/charts/portfolioHistory/PortfolioHistoryChart.logic.ts
+++ b/frontend/src/components/charts/portfolioHistory/PortfolioHistoryChart.logic.ts
@@ -32,8 +32,8 @@ export const useGetPortfolioHistoryChartData = (
   const marketValueHistory = useGetMarketValueHistory(portfolioName);
 
   return historiesToChartData<PortfolioHistoryDataSets>([
-    { history: buyValueHistory, newKey: "buyValue" },
-    { history: cashFlowHistory, newKey: "cashFlow" },
+    { history: extendToToday(buyValueHistory), newKey: "buyValue" },
+    { history: extendToToday(cashFlowHistory), newKey: "cashFlow" },
     { history: marketValueHistory, newKey: "marketValue" },
   ]);
 };
@@ -95,4 +95,11 @@ const historiesToChartData = <Keys extends string>(
   });
 
   return sort(Array.from(map.values()), (p) => p.timestamp);
+};
+
+const extendToToday = (history: History<number>): History<number> => {
+  const lastValue = history.at(-1);
+  return history.concat(
+    lastValue ? [{ timestamp: Date.now(), value: lastValue.value }] : []
+  );
 };


### PR DESCRIPTION
For the histories buyValue and cashFlow, the last value in the history could be long ago, if the user stopped investing. In order see the comparison in the chart more easily, a new data point for the current date is added, using the last value of the history.