### PR TITLE
Feat/daily prices for shorter chart ranges

### DIFF
--- a/frontend/src/components/charts/balancesChart/forecastChart/ForecastChart.logic.ts
+++ b/frontend/src/components/charts/balancesChart/forecastChart/ForecastChart.logic.ts
@@ -74,8 +74,10 @@ export const useForecastScenarioParams = (
   portfolioNames: string[],
   scenario: ForecastScenario
 ): ScenarioDetails | undefined => {
-  const portfolioGbmParams =
-    usePortfolioGeometricBrownianMotionParams(portfolioNames);
+  const portfolioGbmParams = usePortfolioGeometricBrownianMotionParams(
+    portfolioNames,
+    "Max"
+  );
 
   return useMemo(() => {
     if (scenario === "market") {

--- a/frontend/src/components/charts/balancesChart/profitChart/ProfitChart.logic.test.tsx
+++ b/frontend/src/components/charts/balancesChart/profitChart/ProfitChart.logic.test.tsx
@@ -49,7 +49,7 @@ describe("useProfitHistory", () => {
 
   it("handles a missing portfolio gracefully", () => {
     const { result } = customRenderHook(() =>
-      useProfitHistory(["I don't exist"])
+      useProfitHistory(["I don't exist"], "Max")
     );
 
     expect(result.current.data).toEqual([]);
@@ -69,7 +69,7 @@ describe("useProfitHistory", () => {
     );
 
     const { result } = customRenderHook(() =>
-      useProfitHistory(["emptyPortfolio"])
+      useProfitHistory(["emptyPortfolio"], "Max")
     );
 
     expect(result.current).toEqual({
@@ -107,7 +107,7 @@ describe("useProfitHistory", () => {
     );
 
     const result = await renderAndAwaitQueryHook(() =>
-      useProfitHistory(["singleOrderPortfolio"])
+      useProfitHistory(["singleOrderPortfolio"], "Max")
     );
 
     expect(result).toEqual({
@@ -117,6 +117,18 @@ describe("useProfitHistory", () => {
         {
           timestamp: TIMESTAMPS[0],
           value: 0,
+        },
+        {
+          timestamp: TIMESTAMPS[1],
+          value: 1,
+        },
+        {
+          timestamp: TIMESTAMPS[2],
+          value: 2,
+        },
+        {
+          timestamp: TIMESTAMPS[3],
+          value: 3,
         },
         {
           timestamp: TIMESTAMPS[4],
@@ -162,7 +174,7 @@ describe("useProfitHistory", () => {
     );
 
     const result = await renderAndAwaitQueryHook(() =>
-      useProfitHistory(["multipleOrdersSameDayPortfolio"])
+      useProfitHistory(["multipleOrdersSameDayPortfolio"], "Max")
     );
 
     expect(result).toEqual({
@@ -172,6 +184,18 @@ describe("useProfitHistory", () => {
         {
           timestamp: TIMESTAMPS[0],
           value: 1, // this behavior is actually a little hard to define if one day is the smallest timescale that the app considers
+        },
+        {
+          timestamp: TIMESTAMPS[1],
+          value: 1,
+        },
+        {
+          timestamp: TIMESTAMPS[2],
+          value: 3,
+        },
+        {
+          timestamp: TIMESTAMPS[3],
+          value: 5,
         },
         {
           timestamp: TIMESTAMPS[4],
@@ -233,7 +257,7 @@ describe("useProfitHistory", () => {
     );
 
     const result = await renderAndAwaitQueryHook(() =>
-      useProfitHistory(["consecutiveDaysPortfolio"])
+      useProfitHistory(["consecutiveDaysPortfolio"], "Max")
     );
 
     expect(result.data).toEqual([
@@ -296,7 +320,7 @@ describe("useProfitHistory", () => {
     );
 
     const result = await renderAndAwaitQueryHook(() =>
-      useProfitHistory(["nonConsecutiveDaysPortfolio"])
+      useProfitHistory(["nonConsecutiveDaysPortfolio"], "Max")
     );
 
     expect(result.data).toEqual([
@@ -305,8 +329,16 @@ describe("useProfitHistory", () => {
         value: 0,
       },
       {
+        timestamp: TIMESTAMPS[1],
+        value: 1,
+      },
+      {
         timestamp: TIMESTAMPS[2],
         value: 2,
+      },
+      {
+        timestamp: TIMESTAMPS[3],
+        value: 4,
       },
       {
         timestamp: TIMESTAMPS[4],

--- a/frontend/src/components/charts/balancesChart/profitChart/ProfitChart.logic.ts
+++ b/frontend/src/components/charts/balancesChart/profitChart/ProfitChart.logic.ts
@@ -1,15 +1,17 @@
 import { combinePortfolios, getProfitHistory, History } from "pt-domain";
 import { useGetPortfoliosByNames } from "../../../../hooks/portfolios/portfolioHooks";
 import { CustomQuery } from "../../../../hooks/prices/priceHooks";
+import { ChartRange } from "../../chartRange.types";
 import { usePortfolioPriceData } from "../../chartHooks";
 import { usePortfolioTimeAxis } from "../shared/balancesChart.utils";
 
 export const useProfitHistory = (
-  portfolioNames: string[]
+  portfolioNames: string[],
+  range: ChartRange
 ): CustomQuery<History<number>> => {
   const portfolios = useGetPortfoliosByNames(portfolioNames);
   const merged = combinePortfolios(portfolios);
-  const timeAxis = usePortfolioTimeAxis(portfolioNames);
+  const timeAxis = usePortfolioTimeAxis(portfolioNames, range);
   const priceQuery = usePortfolioPriceData(portfolioNames);
 
   const profitHistory = getProfitHistory(merged, priceQuery.data, timeAxis);

--- a/frontend/src/components/charts/balancesChart/profitChart/ProfitChart.tsx
+++ b/frontend/src/components/charts/balancesChart/profitChart/ProfitChart.tsx
@@ -16,7 +16,6 @@ import {
   DEFAULT_LINE_PROPS,
   CHART_GRID_STROKE,
   TOOLTIP_STYLE,
-  filterChartDataByRange,
   getAxisProps,
   getTimeAxisProps,
 } from "../../chartUtils";
@@ -26,23 +25,21 @@ export const ProfitChart: FC<{
   portfolioNames: string[];
   range: ChartRange;
 }> = ({ portfolioNames, range }) => {
-  const { isLoading, data } = useProfitHistory(portfolioNames);
-
-  const chartData = filterChartDataByRange(data ?? [], range);
+  const { isLoading, data } = useProfitHistory(portfolioNames, range);
 
   const { fillUrl, strokeUrl, gradientDefinition } = getSplitColorGradientDef(
-    chartData,
+    data ?? [],
     "value"
   );
 
   return (
     <div>
       <ChartContainer isLoading={isLoading}>
-        <AreaChart data={chartData} margin={{ bottom: 30 }}>
+        <AreaChart data={data ?? []} margin={{ bottom: 30 }}>
           <Legend verticalAlign="bottom" />
-          <XAxis {...getTimeAxisProps(chartData)} />
+          <XAxis {...getTimeAxisProps(data ?? [])} />
           <YAxis
-            {...getAxisProps(chartData)}
+            {...getAxisProps(data ?? [])}
             tickFormatter={(value) => (value / 1000).toString()}
             unit={" k€"}
           />

--- a/frontend/src/components/charts/balancesChart/shared/balancesChart.utils.ts
+++ b/frontend/src/components/charts/balancesChart/shared/balancesChart.utils.ts
@@ -6,9 +6,13 @@ import {
 import { unique } from "radash";
 import { useGetPortfoliosByNames } from "../../../../hooks/portfolios/portfolioHooks";
 import { isNotNil } from "../../../../utility/types";
-import { getDefaultTimeAxis } from "../../chartUtils";
+import { ChartRange } from "../../chartRange.types";
+import { getDefaultTimeAxis, getRangeStart } from "../../chartUtils";
 
-export const usePortfolioTimeAxis = (portfolioNames: string[]): number[] => {
+export const usePortfolioTimeAxis = (
+  portfolioNames: string[],
+  range: ChartRange
+): number[] => {
   const portfolios = useGetPortfoliosByNames(portfolioNames);
 
   if (portfolios.length === 0) {
@@ -25,9 +29,14 @@ export const usePortfolioTimeAxis = (portfolioNames: string[]): number[] => {
     return [];
   }
 
-  const portfolioTimestamps = allActivities.map(getNumericDateTime);
+  const rangeStart = getRangeStart(xMin, range);
+
+  const portfolioTimestamps = allActivities
+    .map(getNumericDateTime)
+    .filter((t) => t >= rangeStart);
+
   return unique(
-    getDefaultTimeAxis(xMin)
+    getDefaultTimeAxis(xMin, range)
       .concat(portfolioTimestamps)
       .concat(Date.now())
       .toSorted((a, b) => a - b)

--- a/frontend/src/components/charts/balancesChart/totalValueChart/TotalValueChart.logic.test.tsx
+++ b/frontend/src/components/charts/balancesChart/totalValueChart/TotalValueChart.logic.test.tsx
@@ -36,6 +36,8 @@ mockNetwork({
   ]),
 });
 
+const DAY_IN_MS = 1000 * 60 * 60 * 24;
+
 describe("useGetPortfolioHistoryChartData", () => {
   const TIMESTAMPS = [DAY1, DAY2, DAY3, DAY4].map((d) =>
     moment(d).startOf("day").valueOf()
@@ -43,7 +45,7 @@ describe("useGetPortfolioHistoryChartData", () => {
 
   it("handles a missing portfolio gracefully", async () => {
     const result = await renderAndAwaitQueryHook(() =>
-      useGetPortfolioHistoryChartData(["I don't exist"])
+      useGetPortfolioHistoryChartData(["I don't exist"], "Max")
     );
 
     expect(result.data).toEqual([]);
@@ -102,7 +104,7 @@ describe("useGetPortfolioHistoryChartData", () => {
     );
 
     const result = renderAndAwaitQueryHook(() =>
-      useGetPortfolioHistoryChartData(["p1"])
+      useGetPortfolioHistoryChartData(["p1"], "Max")
     );
 
     expect((await result).data).toEqual([
@@ -137,6 +139,107 @@ describe("useGetPortfolioHistoryChartData", () => {
         timestamp: moment(TODAY).startOf("day").valueOf(),
       },
     ]);
+  });
+
+  it("includes buyValue and cashFlow for short range when orders predate the range", async () => {
+    // Use a "1M" range but set system time far enough ahead that the
+    // order at DAY1 is outside the 30-day window.
+    // DAY1 = 2020-03-01, we need "today" to be > 30 days after DAY1.
+    vi.setSystemTime("2020-04-10");
+
+    const portfolio = getTestPortfolio({
+      name: "rangeTestPortfolio",
+      orders: getTestOrdersGroupedByAsset([
+        {
+          asset: "a1",
+          pieces: 1,
+          sharePrice: 100,
+          taxes: 0,
+          orderFee: 0,
+          timestamp: DAY1,
+        },
+      ]),
+    });
+
+    const assets: AssetLibrary = {
+      a1: { isin: "a1", symbol: "ABC", displayName: "asset 1" },
+    };
+
+    localStorage.setItem("assets", JSON.stringify(assets));
+    localStorage.setItem(
+      "portfolios",
+      JSON.stringify({ rangeTestPortfolio: portfolio })
+    );
+
+    const result = await renderAndAwaitQueryHook(() =>
+      useGetPortfolioHistoryChartData(["rangeTestPortfolio"], "1M")
+    );
+
+    const chartData = result.data ?? [];
+
+    // Every point within the range should carry buyValue and cashFlow
+    // (carried forward from the pre-range order via pickValueFromHistory)
+    const hasBuyValueAtEveryPoint = chartData.every(
+      (point) => point.buyValue !== undefined
+    );
+    const hasCashFlowAtEveryPoint = chartData.every(
+      (point) => point.cashFlow !== undefined
+    );
+    expect(hasBuyValueAtEveryPoint).toBe(true);
+    expect(hasCashFlowAtEveryPoint).toBe(true);
+
+    // Values should be carried forward from the original order
+    chartData.forEach((point) => {
+      expect(point.buyValue).toBe(100);
+      expect(point.cashFlow).toBe(100);
+    });
+
+    vi.setSystemTime(TODAY);
+  });
+
+  it("does not include pre-range order timestamps in chart data", async () => {
+    // Use a "1M" range with system time far enough ahead that
+    // the order at DAY1 falls outside the 30-day window.
+    vi.setSystemTime("2020-04-10");
+
+    const portfolio = getTestPortfolio({
+      name: "rangeExcludePortfolio",
+      orders: getTestOrdersGroupedByAsset([
+        {
+          asset: "a1",
+          pieces: 1,
+          sharePrice: 100,
+          taxes: 0,
+          orderFee: 0,
+          timestamp: DAY1,
+        },
+      ]),
+    });
+
+    const assets: AssetLibrary = {
+      a1: { isin: "a1", symbol: "ABC", displayName: "asset 1" },
+    };
+
+    localStorage.setItem("assets", JSON.stringify(assets));
+    localStorage.setItem(
+      "portfolios",
+      JSON.stringify({ rangeExcludePortfolio: portfolio })
+    );
+
+    const result = await renderAndAwaitQueryHook(() =>
+      useGetPortfolioHistoryChartData(["rangeExcludePortfolio"], "1M")
+    );
+
+    const chartData = result.data ?? [];
+    const rangeStart =
+      moment("2020-04-10").startOf("day").valueOf() - 30 * DAY_IN_MS;
+
+    const preRangePoints = chartData.filter(
+      (point) => point.timestamp < rangeStart
+    );
+    expect(preRangePoints).toEqual([]);
+
+    vi.setSystemTime(TODAY);
   });
 });
 

--- a/frontend/src/components/charts/balancesChart/totalValueChart/TotalValueChart.logic.ts
+++ b/frontend/src/components/charts/balancesChart/totalValueChart/TotalValueChart.logic.ts
@@ -12,6 +12,7 @@ import { useGetPortfoliosByNames } from "../../../../hooks/portfolios/portfolioH
 import { CustomQuery } from "../../../../hooks/prices/priceHooks";
 import { usePortfolioPriceData } from "../../chartHooks";
 import { ChartDataPoint } from "../../chartTypes";
+import { ChartRange } from "../../chartRange.types";
 import { historiesToChartData } from "../../chartUtils";
 import { usePortfolioTimeAxis } from "../shared/balancesChart.utils";
 
@@ -20,18 +21,29 @@ export type BalancesChartDataSets = "buyValue" | "cashFlow" | "marketValue";
 type BalancesChartData = ChartDataPoint<BalancesChartDataSets>[];
 
 export const useGetPortfolioHistoryChartData = (
-  portfolioNames: string[]
+  portfolioNames: string[],
+  range: ChartRange
 ): CustomQuery<BalancesChartData> => {
   const buyValueHistory = useGetBuyValueHistory(portfolioNames);
   const cashFlowHistory = useGetCashFlowHistory(portfolioNames);
-  const marketValueHistory = useGetMarketValueHistory(portfolioNames);
+  const marketValueHistory = useGetMarketValueHistory(portfolioNames, range);
+  const timeAxis = usePortfolioTimeAxis(portfolioNames, range);
+
+  const buyValueOnAxis = timeAxis.map((timestamp) => ({
+    timestamp,
+    value: pickValueFromHistory(buyValueHistory, timestamp)?.value ?? 0,
+  }));
+  const cashFlowOnAxis = timeAxis.map((timestamp) => ({
+    timestamp,
+    value: pickValueFromHistory(cashFlowHistory, timestamp)?.value ?? 0,
+  }));
 
   return {
     isLoading: marketValueHistory.isLoading,
     isError: marketValueHistory.isError,
     data: historiesToChartData<BalancesChartDataSets>([
-      { history: extendToToday(buyValueHistory), newKey: "buyValue" },
-      { history: extendToToday(cashFlowHistory), newKey: "cashFlow" },
+      { history: extendToToday(buyValueOnAxis), newKey: "buyValue" },
+      { history: extendToToday(cashFlowOnAxis), newKey: "cashFlow" },
       { history: marketValueHistory.data || [], newKey: "marketValue" },
     ]),
   };
@@ -65,11 +77,12 @@ const useGetCashFlowHistory = (portfolioNames: string[]) => {
 };
 
 const useGetMarketValueHistory = (
-  portfolioNames: string[]
+  portfolioNames: string[],
+  range: ChartRange
 ): CustomQuery<History<number>> => {
   const portfolios = useGetPortfoliosByNames(portfolioNames);
   const merged = combinePortfolios(portfolios);
-  const timeAxis = usePortfolioTimeAxis(portfolioNames);
+  const timeAxis = usePortfolioTimeAxis(portfolioNames, range);
   const priceQuery = usePortfolioPriceData(portfolioNames);
 
   return {

--- a/frontend/src/components/charts/balancesChart/totalValueChart/TotalValueChart.tsx
+++ b/frontend/src/components/charts/balancesChart/totalValueChart/TotalValueChart.tsx
@@ -15,7 +15,6 @@ import {
   DEFAULT_LINE_PROPS,
   CHART_GRID_STROKE,
   TOOLTIP_STYLE,
-  filterChartDataByRange,
   getAxisProps,
   getTimeAxisProps,
 } from "../../chartUtils";
@@ -28,18 +27,19 @@ export const TotalValueChart: FC<{
   portfolioNames: string[];
   range: ChartRange;
 }> = ({ portfolioNames, range }) => {
-  const { data, isLoading } = useGetPortfolioHistoryChartData(portfolioNames);
-
-  const chartData = filterChartDataByRange(data || [], range);
+  const { data, isLoading } = useGetPortfolioHistoryChartData(
+    portfolioNames,
+    range
+  );
 
   return (
     <div>
       <ChartContainer isLoading={isLoading}>
-        <LineChart data={chartData} margin={{ bottom: 30 }}>
+        <LineChart data={data || []} margin={{ bottom: 30 }}>
           <Legend verticalAlign="bottom" />
-          <XAxis {...getTimeAxisProps(chartData)} />
+          <XAxis {...getTimeAxisProps(data || [])} />
           <YAxis
-            {...getAxisProps(chartData)}
+            {...getAxisProps(data || [])}
             tickFormatter={(value) => (value / 1000).toString()}
             unit={" k€"}
           />
@@ -49,14 +49,14 @@ export const TotalValueChart: FC<{
             dataKey={"cashFlow" satisfies BalancesChartDataSets}
             name={"Cash Flow"}
             stroke="var(--color-accent-hover)"
-            strokeOpacity={chartData.length ? 1 : 0.5}
+            strokeOpacity={data?.length ? 1 : 0.5}
           />
           <Line
             {...DEFAULT_LINE_PROPS}
             dataKey={"buyValue" satisfies BalancesChartDataSets}
             name={"Buy Value"}
             stroke="var(--color-warning)"
-            strokeOpacity={chartData.length ? 1 : 0.5}
+            strokeOpacity={data?.length ? 1 : 0.5}
           />
           <Line
             {...DEFAULT_LINE_PROPS}
@@ -64,7 +64,7 @@ export const TotalValueChart: FC<{
             name={"Market Value"}
             stroke="var(--color-success)"
             type={"linear"}
-            strokeOpacity={chartData.length ? 1 : 0.5}
+            strokeOpacity={data?.length ? 1 : 0.5}
           />
           <Tooltip
             contentStyle={TOOLTIP_STYLE}

--- a/frontend/src/components/charts/chartHooks.ts
+++ b/frontend/src/components/charts/chartHooks.ts
@@ -13,6 +13,7 @@ import {
   CustomQuery,
   useGetPricesForIsins,
 } from "../../hooks/prices/priceHooks";
+import { ChartRange } from "./chartRange.types";
 import { getDefaultTimeAxis } from "./chartUtils";
 
 export const usePortfolioPriceData = (portfolioNames: string[]) => {
@@ -22,7 +23,8 @@ export const usePortfolioPriceData = (portfolioNames: string[]) => {
 };
 
 export const useTimeWeightedReturnHistory = (
-  portfolioNames: string[]
+  portfolioNames: string[],
+  range: ChartRange
 ): CustomQuery<History<number>> | undefined => {
   const portfolios = useGetPortfoliosByNames(portfolioNames);
   const merged = combinePortfolios(portfolios);
@@ -35,15 +37,16 @@ export const useTimeWeightedReturnHistory = (
     data: getTimeWeightedReturnHistory(
       merged,
       priceMapQuery.data,
-      xMin ? getDefaultTimeAxis(xMin) : undefined
+      xMin ? getDefaultTimeAxis(xMin, range) : undefined
     ).map(getHistoryPointMapper(rel2percentage)),
   };
 };
 
 export const usePortfolioGeometricBrownianMotionParams = (
-  portfolioNames: string[]
+  portfolioNames: string[],
+  range: ChartRange
 ): GbmParameters | undefined => {
-  const twrHistory = useTimeWeightedReturnHistory(portfolioNames);
+  const twrHistory = useTimeWeightedReturnHistory(portfolioNames, range);
   const data = twrHistory?.data || [];
 
   return getGeometricBrownianMotionParams(

--- a/frontend/src/components/charts/chartUtils.test.ts
+++ b/frontend/src/components/charts/chartUtils.test.ts
@@ -1,108 +1,81 @@
-import moment from "moment";
 import { vi } from "vitest";
-import { ChartRange } from "./chartRange.types";
-import { ChartData } from "./chartTypes";
-import { filterChartDataByRange } from "./chartUtils";
+import { CHART_RANGE_DAYS } from "./chartRange.types";
+import { getDefaultTimeAxis } from "./chartUtils";
 
+const DAY_IN_MS = 1000 * 60 * 60 * 24;
 const TODAY = "2020-03-05";
 vi.setSystemTime(TODAY);
 
-const createTestData = (daysAgo: number[]): ChartData<"value"> => {
-  const todayTimestamp = moment(TODAY).startOf("day").valueOf();
-  return daysAgo.map((days, index) => ({
-    timestamp: todayTimestamp - days * 24 * 60 * 60 * 1000,
-    value: index + 1,
-  }));
-};
+const todayMs = new Date(TODAY).getTime();
 
-describe("filterChartDataByRange", () => {
-  it("returns unmodified data for Max range", () => {
-    const data = createTestData([0, 10, 30, 100]);
+describe("getDefaultTimeAxis", () => {
+  const xMin = todayMs - 100 * DAY_IN_MS;
 
-    const result = filterChartDataByRange(data, "Max");
-
-    expect(result).toEqual(data);
+  it("uses daily step for 1M range", () => {
+    const axis = getDefaultTimeAxis(xMin, "1M");
+    const steps = axis.slice(1).map((t, i) => t - axis[i]);
+    expect(steps.every((s) => s === DAY_IN_MS)).toBe(true);
   });
 
-  it("returns empty array unchanged", () => {
-    const result = filterChartDataByRange([], "1M");
-
-    expect(result).toEqual([]);
+  it("uses daily step for 3M range", () => {
+    const axis = getDefaultTimeAxis(xMin, "3M");
+    const steps = axis.slice(1).map((t, i) => t - axis[i]);
+    expect(steps.every((s) => s === DAY_IN_MS)).toBe(true);
   });
 
-  it("filters to last 30 days for 1M range", () => {
-    const data = createTestData([0, 15, 29, 30, 31, 60]);
-
-    const result = filterChartDataByRange(data, "1M");
-
-    expect(result).toHaveLength(4);
-    expect(result.map((d) => d.value)).toEqual([1, 2, 3, 4]);
+  it("uses daily step for 1Y range", () => {
+    const axis = getDefaultTimeAxis(xMin, "1Y");
+    const steps = axis.slice(1).map((t, i) => t - axis[i]);
+    expect(steps.every((s) => s === DAY_IN_MS)).toBe(true);
   });
 
-  it("filters to last 90 days for 3M range", () => {
-    const data = createTestData([0, 30, 89, 90, 91, 120]);
-
-    const result = filterChartDataByRange(data, "3M");
-
-    expect(result).toHaveLength(4);
-    expect(result.map((d) => d.value)).toEqual([1, 2, 3, 4]);
+  it("uses weekly step for 3Y range", () => {
+    const oldXMin = todayMs - 1200 * DAY_IN_MS;
+    const axis = getDefaultTimeAxis(oldXMin, "3Y");
+    const steps = axis.slice(1).map((t, i) => t - axis[i]);
+    expect(steps.slice(0, -1).every((s) => s === 7 * DAY_IN_MS)).toBe(true);
   });
 
-  it("filters to last 365 days for 1Y range", () => {
-    const data = createTestData([0, 100, 364, 365, 366]);
-
-    const result = filterChartDataByRange(data, "1Y");
-
-    expect(result).toHaveLength(4);
-    expect(result.map((d) => d.value)).toEqual([1, 2, 3, 4]);
+  it("uses weekly step for 10Y range", () => {
+    const oldXMin = todayMs - 4000 * DAY_IN_MS;
+    const axis = getDefaultTimeAxis(oldXMin, "10Y");
+    const steps = axis.slice(1).map((t, i) => t - axis[i]);
+    expect(steps.slice(0, -1).every((s) => s === 7 * DAY_IN_MS)).toBe(true);
   });
 
-  it("filters to last 1095 days for 3Y range", () => {
-    const data = createTestData([0, 365, 1094, 1095, 1096]);
-
-    const result = filterChartDataByRange(data, "3Y");
-
-    expect(result).toHaveLength(4);
-    expect(result.map((d) => d.value)).toEqual([1, 2, 3, 4]);
+  it("clamps start to rangeStart when rangeStart > xMin", () => {
+    const axis = getDefaultTimeAxis(xMin, "1M");
+    const rangeStart = todayMs - CHART_RANGE_DAYS["1M"]! * DAY_IN_MS;
+    expect(axis[0]).toBe(rangeStart);
   });
 
-  it("filters to last 3650 days for 10Y range", () => {
-    const data = createTestData([0, 1000, 3649, 3650, 3651]);
-
-    const result = filterChartDataByRange(data, "10Y");
-
-    expect(result).toHaveLength(4);
-    expect(result.map((d) => d.value)).toEqual([1, 2, 3, 4]);
+  it("uses xMin as start when xMin > rangeStart", () => {
+    const recentXMin = todayMs - 5 * DAY_IN_MS;
+    const axis = getDefaultTimeAxis(recentXMin, "1Y");
+    expect(axis[0]).toBe(recentXMin);
   });
 
-  it("handles data smaller than requested range", () => {
-    const data = createTestData([0, 5, 10]);
-
-    const result = filterChartDataByRange(data, "10Y" as ChartRange);
-
-    expect(result).toEqual(data);
+  it("Max uses daily step when span <= 365 days", () => {
+    const recentXMin = todayMs - 200 * DAY_IN_MS;
+    const axis = getDefaultTimeAxis(recentXMin, "Max");
+    const steps = axis.slice(1).map((t, i) => t - axis[i]);
+    expect(steps.every((s) => s === DAY_IN_MS)).toBe(true);
   });
 
-  it("includes data point at boundary", () => {
-    const todayTimestamp = moment(TODAY).startOf("day").valueOf();
-    const boundaryTimestamp = todayTimestamp - 30 * 24 * 60 * 60 * 1000;
-    const data = [
-      { timestamp: boundaryTimestamp, value: 1 },
-      { timestamp: boundaryTimestamp - 1, value: 2 },
-    ];
-
-    const result = filterChartDataByRange(data, "1M");
-
-    expect(result).toHaveLength(1);
-    expect(result[0].value).toBe(1);
+  it("Max uses weekly step when span > 365 days", () => {
+    const oldXMin = todayMs - 400 * DAY_IN_MS;
+    const axis = getDefaultTimeAxis(oldXMin, "Max");
+    const steps = axis.slice(1).map((t, i) => t - axis[i]);
+    expect(steps.slice(0, -1).every((s) => s === 7 * DAY_IN_MS)).toBe(true);
   });
 
-  it("does not mutate original data", () => {
-    const data = createTestData([0, 15, 60]);
-    const originalData = [...data];
+  it("always ends with Date.now()", () => {
+    const axis = getDefaultTimeAxis(xMin, "1M");
+    expect(axis[axis.length - 1]).toBe(todayMs);
+  });
 
-    filterChartDataByRange(data, "1M");
-
-    expect(data).toEqual(originalData);
+  it("returns no duplicate timestamps", () => {
+    const axis = getDefaultTimeAxis(xMin, "1M");
+    expect(new Set(axis).size).toBe(axis.length);
   });
 });

--- a/frontend/src/components/charts/chartUtils.ts
+++ b/frontend/src/components/charts/chartUtils.ts
@@ -11,7 +11,6 @@ import { CHART_RANGE_DAYS, ChartRange } from "./chartRange.types";
 import { ChartData, ChartDataPoint } from "./chartTypes";
 
 const MARGIN = 0.05;
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export const CHART_GRID_STROKE = "var(--color-border)";
 
@@ -20,21 +19,6 @@ export const TOOLTIP_STYLE: React.CSSProperties = {
   border: "1px solid var(--color-border)",
   borderRadius: "0.375rem",
   color: "var(--color-text)",
-};
-
-export const filterChartDataByRange = <Keys extends string>(
-  chartData: ChartData<Keys>,
-  range: ChartRange
-): ChartData<Keys> => {
-  const days = CHART_RANGE_DAYS[range];
-  if (range === "Max" || chartData.length === 0 || days == null) {
-    return chartData;
-  }
-
-  const now = moment().startOf("day").valueOf();
-  const rangeStart = now - days * MS_PER_DAY;
-
-  return chartData.filter((point) => point.timestamp >= rangeStart);
 };
 
 export function getAxisProps(
@@ -127,13 +111,24 @@ export const DEFAULT_LINE_PROPS = {
 } as const;
 
 const DAY_IN_MS = 1000 * 60 * 60 * 24;
+const DAILY_THRESHOLD_DAYS = 365;
 
-export const getDefaultTimeAxis = (xMin: number) =>
-  unique(
-    Array.from(range(xMin, Date.now(), (i) => i, 7 * DAY_IN_MS)).concat(
-      Date.now()
-    )
+export const getRangeStart = (xMin: number, range: ChartRange): number => {
+  const days = CHART_RANGE_DAYS[range];
+  return days != null ? Math.max(xMin, Date.now() - days * DAY_IN_MS) : xMin;
+};
+
+export const getDefaultTimeAxis = (xMin: number, chartRange: ChartRange) => {
+  const rangeStart = getRangeStart(xMin, chartRange);
+
+  const effectiveSpanDays = (Date.now() - rangeStart) / DAY_IN_MS;
+  const step =
+    effectiveSpanDays <= DAILY_THRESHOLD_DAYS ? DAY_IN_MS : 7 * DAY_IN_MS;
+
+  return unique(
+    Array.from(range(rangeStart, Date.now(), (i) => i, step)).concat(Date.now())
   );
+};
 
 export function calculateGradientOffset<T>(
   data: T[],

--- a/frontend/src/components/charts/timeWeightedReturnChart/TimeWeightedReturnChart.logic.ts
+++ b/frontend/src/components/charts/timeWeightedReturnChart/TimeWeightedReturnChart.logic.ts
@@ -50,6 +50,21 @@ const usePerformanceBenchmark = (
   });
 };
 
+const anchorHistoryToRangeStart = (
+  history: History<number>,
+  anchorPoint: History<number>[number] | undefined,
+  rangeStart: number
+): History<number> =>
+  anchorPoint
+    ? select(
+        history,
+        getHistoryPointMapper((p) =>
+          rel2percentage(percentage2rel(p) / percentage2rel(anchorPoint.value))
+        ),
+        (p) => p.timestamp >= rangeStart
+      )
+    : history.filter((p) => p.timestamp >= rangeStart);
+
 export type PerformanceChartDataSets = "portfolio" | "benchmark";
 
 export const usePerformanceChartData = (
@@ -64,6 +79,7 @@ export const usePerformanceChartData = (
   );
 
   const twrHistory = twrHistoryQuery?.data ?? [];
+  // priceHistory from API is in descending order
   const benchmarkHistory = benchmarkHistoryQuery?.data ?? [];
 
   const benchmarkStart = last(benchmarkHistory)?.timestamp;
@@ -84,11 +100,28 @@ export const usePerformanceChartData = (
 
   const rangeStart = getRangeStart(-Infinity, range);
 
-  const rangeFilteredTwr = adjustedTwrHistory.filter(
-    (p) => p.timestamp >= rangeStart
+  // TWR history is ascending (from domain), benchmark history is descending
+  // (from API) — hence the different order modes for pickValueFromHistory.
+  const twrAtRangeStart = pickValueFromHistory(
+    adjustedTwrHistory,
+    rangeStart,
+    "ascending"
   );
-  const rangeFilteredBenchmark = benchmarkHistory.filter(
-    (p) => p.timestamp >= rangeStart
+  const benchmarkAtRangeStart = pickValueFromHistory(
+    benchmarkHistory,
+    rangeStart,
+    "descending"
+  );
+
+  const rangeAnchoredTwr = anchorHistoryToRangeStart(
+    adjustedTwrHistory,
+    twrAtRangeStart,
+    rangeStart
+  );
+  const rangeAnchoredBenchmark = anchorHistoryToRangeStart(
+    benchmarkHistory,
+    benchmarkAtRangeStart,
+    rangeStart
   );
 
   return {
@@ -97,8 +130,8 @@ export const usePerformanceChartData = (
     isError:
       twrHistoryQuery?.isError || benchmarkHistoryQuery?.isError || false,
     data: historiesToChartData([
-      { history: rangeFilteredTwr, newKey: "portfolio" },
-      { history: rangeFilteredBenchmark, newKey: "benchmark" },
+      { history: rangeAnchoredTwr, newKey: "portfolio" },
+      { history: rangeAnchoredBenchmark, newKey: "benchmark" },
     ]),
   };
 };

--- a/frontend/src/components/charts/timeWeightedReturnChart/TimeWeightedReturnChart.logic.ts
+++ b/frontend/src/components/charts/timeWeightedReturnChart/TimeWeightedReturnChart.logic.ts
@@ -14,8 +14,9 @@ import {
   rel2percentage,
   useTimeWeightedReturnHistory,
 } from "../chartHooks";
+import { ChartRange } from "../chartRange.types";
 import { ChartData } from "../chartTypes";
-import { historiesToChartData } from "../chartUtils";
+import { getRangeStart, historiesToChartData } from "../chartUtils";
 
 const usePerformanceBenchmark = (
   portfolioNames: string[],
@@ -53,9 +54,10 @@ export type PerformanceChartDataSets = "portfolio" | "benchmark";
 
 export const usePerformanceChartData = (
   portfolioNames: string[],
-  benchmarkIsin: string
+  benchmarkIsin: string,
+  range: ChartRange
 ): CustomQuery<ChartData<PerformanceChartDataSets>> => {
-  const twrHistoryQuery = useTimeWeightedReturnHistory(portfolioNames);
+  const twrHistoryQuery = useTimeWeightedReturnHistory(portfolioNames, range);
   const benchmarkHistoryQuery = usePerformanceBenchmark(
     portfolioNames,
     benchmarkIsin
@@ -80,14 +82,23 @@ export const usePerformanceChartData = (
       )
     : twrHistory;
 
+  const rangeStart = getRangeStart(-Infinity, range);
+
+  const rangeFilteredTwr = adjustedTwrHistory.filter(
+    (p) => p.timestamp >= rangeStart
+  );
+  const rangeFilteredBenchmark = benchmarkHistory.filter(
+    (p) => p.timestamp >= rangeStart
+  );
+
   return {
     isLoading:
       twrHistoryQuery?.isLoading || benchmarkHistoryQuery?.isLoading || false,
     isError:
       twrHistoryQuery?.isError || benchmarkHistoryQuery?.isError || false,
     data: historiesToChartData([
-      { history: adjustedTwrHistory, newKey: "portfolio" },
-      { history: benchmarkHistory, newKey: "benchmark" },
+      { history: rangeFilteredTwr, newKey: "portfolio" },
+      { history: rangeFilteredBenchmark, newKey: "benchmark" },
     ]),
   };
 };

--- a/frontend/src/components/charts/timeWeightedReturnChart/TimeWeightedReturnChart.tsx
+++ b/frontend/src/components/charts/timeWeightedReturnChart/TimeWeightedReturnChart.tsx
@@ -19,7 +19,6 @@ import {
   DEFAULT_LINE_PROPS,
   CHART_GRID_STROKE,
   TOOLTIP_STYLE,
-  filterChartDataByRange,
   getAxisProps,
   getTimeAxisProps,
 } from "../chartUtils";
@@ -36,13 +35,12 @@ export const TimeWeightedReturnChart: FC<{ portfolioNames: string[] }> = ({
   const [range, setRange] = useState<ChartRange>("Max");
   const { isLoading, data } = usePerformanceChartData(
     portfolioNames,
-    benchmark
+    benchmark,
+    range
   );
 
-  const chartData = filterChartDataByRange(data || [], range);
-
   const { gradientDefinition, fillUrl, strokeUrl } = getSplitColorGradientDef(
-    chartData,
+    data || [],
     "portfolio"
   );
 
@@ -63,11 +61,11 @@ export const TimeWeightedReturnChart: FC<{ portfolioNames: string[] }> = ({
           </div>
         </div>
         <ChartContainer isLoading={isLoading}>
-          <AreaChart data={chartData} margin={{ bottom: 30 }}>
+          <AreaChart data={data || []} margin={{ bottom: 30 }}>
             <Legend verticalAlign="bottom" />
-            <XAxis {...getTimeAxisProps(chartData)} />
+            <XAxis {...getTimeAxisProps(data || [])} />
             <YAxis
-              {...getAxisProps(chartData)}
+              {...getAxisProps(data || [])}
               tickFormatter={(value) => Number(value).toFixed(0)}
               unit={" %"}
             />

--- a/frontend/src/components/charts/timeWeightedReturnChart/TimeWeightedReturnChartLogic.test.tsx
+++ b/frontend/src/components/charts/timeWeightedReturnChart/TimeWeightedReturnChartLogic.test.tsx
@@ -7,6 +7,8 @@ import { getPriceResponse, mockNetwork } from "../../../testUtils/networkMock";
 import { ChartData } from "../chartTypes";
 import { usePerformanceChartData } from "./TimeWeightedReturnChart.logic";
 
+const DAY_IN_MS = 1000 * 60 * 60 * 24;
+
 const ASSET = "asset1";
 const BENCHMARK = "benchmark";
 
@@ -60,9 +62,66 @@ const portfolio = getTestPortfolio({
   ]),
 });
 
+const MATURE_ASSET = "matureAsset";
+
+const MATURE_DAY1 = new Date("1999-10-01");
+const MATURE_DAY2 = new Date("2000-01-01");
+const MATURE_DAY3 = new Date("2000-01-02");
+const MATURE_DAY4 = new Date("2000-01-04");
+
+const maturePortfolio = getTestPortfolio({
+  orders: getTestOrdersGroupedByAsset([
+    {
+      asset: MATURE_ASSET,
+      pieces: 1,
+      sharePrice: 100,
+      taxes: 0,
+      orderFee: 0,
+      timestamp: MATURE_DAY1.toISOString(),
+    },
+    {
+      asset: MATURE_ASSET,
+      pieces: 1,
+      sharePrice: 120,
+      taxes: 0,
+      orderFee: 0,
+      timestamp: MATURE_DAY2.toISOString(),
+    },
+    {
+      asset: MATURE_ASSET,
+      pieces: 1,
+      sharePrice: 122,
+      taxes: 0,
+      orderFee: 0,
+      timestamp: MATURE_DAY3.toISOString(),
+    },
+    {
+      asset: MATURE_ASSET,
+      pieces: 1,
+      sharePrice: 126,
+      taxes: 0,
+      orderFee: 0,
+      timestamp: MATURE_DAY4.toISOString(),
+    },
+  ]),
+});
+
+const matureAssetLib = {
+  [MATURE_ASSET]: {
+    isin: MATURE_ASSET,
+    displayName: "not relevant",
+    symbol: "ma",
+  },
+};
+
+const allAssets = { ...assetLib, ...matureAssetLib };
+
 setUserData({
-  portfolios: { [portfolio.name]: portfolio },
-  assets: assetLib,
+  portfolios: {
+    [portfolio.name]: portfolio,
+    [maturePortfolio.name]: maturePortfolio,
+  },
+  assets: allAssets,
 });
 
 vi.setSystemTime(TODAY);
@@ -172,6 +231,197 @@ describe("the hook", () => {
           },
         ]
       );
+    });
+  });
+
+  describe("range-relative anchoring", () => {
+    // Portfolio with gains both before and after the 1M range boundary.
+    // MATURE_DAY1 (Oct 1) is ~96 days before TODAY (Jan 5), well before
+    // the 1M range start (Dec 6). Price data creates a 20% gain before
+    // the range start and additional gains within the range.
+    const ONE_MONTH_MS = 30 * DAY_IN_MS;
+    const RANGE_START_DATE = new Date(TODAY.getTime() - ONE_MONTH_MS);
+
+    it("starts at 0% for 1M range when portfolio is older than 1M", async () => {
+      // Price at 120 from Oct through Dec creates pre-range gains
+      setBackendData({
+        prices: getPriceResponse("ma", [
+          [MATURE_DAY1, 100],
+          [RANGE_START_DATE, 120],
+          [MATURE_DAY4, 126],
+          [TODAY, 126],
+        ]),
+      });
+
+      const result = await renderAndAwaitQueryHook(() =>
+        usePerformanceChartData([maturePortfolio.name], "", "1M")
+      );
+
+      const data = result.data ?? [];
+      expect(data.length).toBeGreaterThan(0);
+
+      // The first visible point should be anchored at 0%
+      const firstPortfolioValue = data[0].portfolio ?? 0;
+      expect(firstPortfolioValue).toBeCloseTo(0, 1);
+    });
+
+    it("starts at 0% for Max range", async () => {
+      setBackendData({
+        prices: getPriceResponse("ma", [
+          [MATURE_DAY1, 100],
+          [RANGE_START_DATE, 120],
+          [MATURE_DAY4, 126],
+          [TODAY, 126],
+        ]),
+      });
+
+      const result = await renderAndAwaitQueryHook(() =>
+        usePerformanceChartData([maturePortfolio.name], "", "Max")
+      );
+
+      const data = result.data ?? [];
+      expect(data.length).toBeGreaterThan(0);
+
+      const firstPortfolioValue = data[0].portfolio ?? 0;
+      expect(firstPortfolioValue).toBeCloseTo(0, 1);
+    });
+
+    it("1M range shows smaller return than Max at end of range", async () => {
+      setBackendData({
+        prices: getPriceResponse("ma", [
+          [MATURE_DAY1, 100],
+          [RANGE_START_DATE, 120],
+          [MATURE_DAY4, 126],
+          [TODAY, 126],
+        ]),
+      });
+
+      const maxResult = await renderAndAwaitQueryHook(() =>
+        usePerformanceChartData([maturePortfolio.name], "", "Max")
+      );
+
+      // Re-initialize user data between hook renders to ensure clean state
+      setUserData({
+        portfolios: {
+          [portfolio.name]: portfolio,
+          [maturePortfolio.name]: maturePortfolio,
+        },
+        assets: allAssets,
+      });
+
+      const oneMonthResult = await renderAndAwaitQueryHook(() =>
+        usePerformanceChartData([maturePortfolio.name], "", "1M")
+      );
+
+      const maxData = maxResult.data ?? [];
+      const oneMonthData = oneMonthResult.data ?? [];
+
+      expect(maxData.length).toBeGreaterThan(0);
+      expect(oneMonthData.length).toBeGreaterThan(0);
+
+      const lastMaxValue = maxData[maxData.length - 1].portfolio ?? 0;
+      const lastOneMonthValue =
+        oneMonthData[oneMonthData.length - 1].portfolio ?? 0;
+
+      // Values may be number or number[] (forecast uncertainty bands)
+      const maxNumber = typeof lastMaxValue === "number" ? lastMaxValue : 0;
+      const oneMonthNumber =
+        typeof lastOneMonthValue === "number" ? lastOneMonthValue : 0;
+
+      // Max shows inception-to-date return (includes Oct→Dec gain)
+      // 1M shows only the gain within the 1M window (Dec→Jan)
+      expect(maxNumber).toBeGreaterThan(oneMonthNumber);
+    });
+
+    it("benchmark also starts at 0% for 1M range", async () => {
+      // Use the mature portfolio + benchmark with long history.
+      // The 1M range start is Dec 6, portfolio starts Oct 1,
+      // benchmark starts even earlier.
+      setBackendData({
+        prices: {
+          ...getPriceResponse("ma", [
+            [MATURE_DAY1, 100],
+            [RANGE_START_DATE, 120],
+            [MATURE_DAY4, 126],
+            [TODAY, 126],
+          ]),
+          ...getPriceResponse("b1", [
+            [MATURE_DAY1, 50],
+            [RANGE_START_DATE, 60],
+            [MATURE_DAY4, 63],
+            [TODAY, 63],
+          ]),
+        },
+      });
+
+      const result = await renderAndAwaitQueryHook(() =>
+        usePerformanceChartData(
+          [maturePortfolio.name],
+          assetLib[BENCHMARK].isin,
+          "1M"
+        )
+      );
+
+      const data = result.data ?? [];
+      expect(data.length).toBeGreaterThan(0);
+
+      // The first visible benchmark point should also be anchored at 0%
+      const firstBenchmarkValue = data[0].benchmark ?? 0;
+      const benchmarkNumber =
+        typeof firstBenchmarkValue === "number" ? firstBenchmarkValue : 0;
+      expect(benchmarkNumber).toBeCloseTo(0, 1);
+    });
+
+    it("1M range first point timestamp is after portfolio inception", async () => {
+      setBackendData({
+        prices: getPriceResponse("ma", [
+          [MATURE_DAY1, 100],
+          [RANGE_START_DATE, 120],
+          [MATURE_DAY4, 126],
+          [TODAY, 126],
+        ]),
+      });
+
+      const result = await renderAndAwaitQueryHook(() =>
+        usePerformanceChartData([maturePortfolio.name], "", "1M")
+      );
+
+      const data = result.data ?? [];
+      expect(data.length).toBeGreaterThan(0);
+
+      // The first timestamp should be well after the portfolio inception
+      // (which is MATURE_DAY1 = Oct 1, months before the 1M range start)
+      expect(data[0].timestamp).toBeGreaterThan(
+        MATURE_DAY1.getTime() + DAY_IN_MS
+      );
+    });
+
+    it("falls back to simple filter when no data at range start", async () => {
+      // Portfolio starts on DAY1 (Jan 1, 2000), which is within the 1M
+      // range (Dec 6 – Jan 5). Since the portfolio inception is after
+      // the 1M range start, pickValueFromHistory returns undefined and
+      // the fallback path (simple filter) is taken.
+      setBackendData({
+        prices: getPriceResponse("a", [
+          [DAY1, 100],
+          [DAY2, 101],
+          [DAY3, 102],
+          [DAY4, 103],
+          [TODAY, 103],
+        ]),
+      });
+
+      const result = await renderAndAwaitQueryHook(() =>
+        usePerformanceChartData([portfolio.name], "", "1M")
+      );
+
+      const data = result.data ?? [];
+      expect(data.length).toBeGreaterThan(0);
+
+      // Since the portfolio starts within the range, no anchoring is
+      // needed and the first point should still be at 0% (inception)
+      const firstPortfolioValue = data[0].portfolio ?? 0;
+      expect(firstPortfolioValue).toBeCloseTo(0, 1);
     });
   });
 });

--- a/frontend/src/components/charts/timeWeightedReturnChart/TimeWeightedReturnChartLogic.test.tsx
+++ b/frontend/src/components/charts/timeWeightedReturnChart/TimeWeightedReturnChartLogic.test.tsx
@@ -74,7 +74,11 @@ describe("the hook", () => {
       setBackendData({ prices: getPriceResponse("a", []) });
 
       const result = await renderAndAwaitQueryHook(() =>
-        usePerformanceChartData(["does not exist"], "does not exist either")
+        usePerformanceChartData(
+          ["does not exist"],
+          "does not exist either",
+          "Max"
+        )
       );
 
       expect(result).toEqual({
@@ -87,7 +91,7 @@ describe("the hook", () => {
     it("returns only twr if no benchmark symbol is given", async () => {
       setBackendData({ prices: getPriceResponse("a", []) });
       const result = await renderAndAwaitQueryHook(() =>
-        usePerformanceChartData([portfolio.name], "")
+        usePerformanceChartData([portfolio.name], "", "Max")
       );
 
       expectChartsAreEqualForKeys(["portfolio"], result.data ?? [], [
@@ -111,7 +115,11 @@ describe("the hook", () => {
         ]),
       });
       const result = await renderAndAwaitQueryHook(() =>
-        usePerformanceChartData([portfolio.name], assetLib[BENCHMARK].isin)
+        usePerformanceChartData(
+          [portfolio.name],
+          assetLib[BENCHMARK].isin,
+          "Max"
+        )
       );
 
       expectChartsAreEqualForKeys(
@@ -136,7 +144,11 @@ describe("the hook", () => {
         ]),
       });
       const result = await renderAndAwaitQueryHook(() =>
-        usePerformanceChartData([portfolio.name], assetLib[BENCHMARK].isin)
+        usePerformanceChartData(
+          [portfolio.name],
+          assetLib[BENCHMARK].isin,
+          "Max"
+        )
       );
 
       expectChartsAreEqualForKeys(


### PR DESCRIPTION
- use a higher data point frequency for shorter selected chart ranges
- show performance (TWR) relative to start of selected range, not relative to start of portfolio