### PR TITLE
fix(asset-select): render popover above sheet on mobile

### DIFF
--- a/frontend/src/components/Assets/AssetDropdown/AssetSelect.styles.ts
+++ b/frontend/src/components/Assets/AssetDropdown/AssetSelect.styles.ts
@@ -8,7 +8,7 @@ export const styles = {
   label: "block text-sm font-medium text-text-muted mb-1.5",
   errorMessage: "mt-1 text-xs text-danger",
   popoverContent:
-    "w-[var(--radix-popover-trigger-width)] rounded-md border border-border bg-bg-card shadow-md p-0",
+    "z-[1300] w-[var(--radix-popover-trigger-width)] rounded-md border border-border bg-bg-card shadow-md p-0",
   commandRoot: "flex flex-col overflow-hidden",
   commandInput:
     "w-full px-3 py-2.5 text-sm bg-transparent text-text placeholder:text-text-dim focus:outline-none border-b border-border",

--- a/frontend/src/components/Assets/AssetDropdown/AssetSelect.tsx
+++ b/frontend/src/components/Assets/AssetDropdown/AssetSelect.tsx
@@ -58,7 +58,7 @@ const AssetDropdown = ({
           {label}
         </label>
       )}
-      <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Root open={open} onOpenChange={setOpen} modal>
         <Popover.Trigger asChild>
           <button
             id={selectId}


### PR DESCRIPTION
The asset combobox popover was hidden behind the Sheet (Radix Dialog) on mobile because it had no z-index while the sheet uses z-[1200]. Adding modal to Popover.Root also resolves the focus trap and outside-interaction conflicts with the Dialog's focus scope.